### PR TITLE
[C++] Sanitize operation IDs.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
@@ -128,6 +128,11 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
     }
 
     @Override
+    public String toOperationId(String operationId) {
+        return sanitizeName(super.toOperationId(operationId));
+    }
+
+    @Override
     public String toParamName(String name) {
         return sanitizeName(super.toParamName(name));
     }


### PR DESCRIPTION
Each operation described in a swagger spec has an ID which is used by the generator directly to define the corresponding function name.
This PR makes sure `operationId`s are sanitized, so that valid C++ code is generated (no spaces, dots, etc in function names).