### PR TITLE
Feature/cpprest remove u macro

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -312,7 +312,7 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
     @Override
     public String toDefaultValue(Property p) {
         if (p instanceof StringProperty) {
-            return "U(\"\")";
+            return "utility::conversions::to_string_t(\"\")";
         } else if (p instanceof BooleanProperty) {
             return "false";
         } else if (p instanceof DateProperty) {

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
@@ -32,13 +32,13 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     // verify the required parameter '{{paramName}}' is set
     if ({{paramName}} == nullptr)
     {
-        throw ApiException(400, U("Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}"));
+        throw ApiException(400, utility::conversions::to_string_t("Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}"));
     }
 {{/isContainer}}{{/isPrimitiveType}}{{/required}}{{/allParams}}
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("{{{path}}}");
-    {{#pathParams}}boost::replace_all(path, U("{") U("{{baseName}}") U("}"), ApiClient::parameterToString({{{paramName}}}));
+    utility::string_t path = utility::conversions::to_string_t("{{{path}}}");
+    {{#pathParams}}boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("{{baseName}}") + utility::conversions::to_string_t("}"), ApiClient::parameterToString({{{paramName}}}));
     {{/pathParams}}
 
     std::map<utility::string_t, utility::string_t> queryParams;
@@ -48,7 +48,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
     {{#produces}}
-    responseHttpContentTypes.insert( U("{{mediaType}}") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("{{mediaType}}") );
     {{/produces}}
 
     utility::string_t responseHttpContentType;
@@ -57,27 +57,27 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     if ( responseHttpContentTypes.size() == 0 )
     {
         {{#vendorExtensions.x-codegen-response.isString}}
-        responseHttpContentType = U("text/plain");
+        responseHttpContentType = utility::conversions::to_string_t("text/plain");
         {{/vendorExtensions.x-codegen-response.isString}}
         {{^vendorExtensions.x-codegen-response.isString}}
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
         {{/vendorExtensions.x-codegen-response.isString}}
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     {{#vendorExtensions.x-codegen-response.isString}}
     // plain text
-    else if( responseHttpContentTypes.find(U("text/plain")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("text/plain")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("text/plain");
+        responseHttpContentType = utility::conversions::to_string_t("text/plain");
     }
     {{/vendorExtensions.x-codegen-response.isString}}
     {{#vendorExtensions.x-codegen-response-ishttpcontent}}
@@ -90,15 +90,15 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{^vendorExtensions.x-codegen-response-ishttpcontent}}
     else
     {
-        throw ApiException(400, U("{{classname}}->{{operationId}} does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("{{classname}}->{{operationId}} does not produce any supported media type"));
     }
     {{/vendorExtensions.x-codegen-response-ishttpcontent}}
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
     {{#consumes}}
-    consumeHttpContentTypes.insert( U("{{mediaType}}") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("{{mediaType}}") );
     {{/consumes}}
 
     {{#allParams}}
@@ -108,30 +108,30 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {
         {{#isContainer}}
         {{#isQueryParam}}
-        queryParams[U("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
         {{/isQueryParam}}
         {{#isHeaderParam}}
-        headerParams[U("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
         {{/isHeaderParam}}
         {{#isFormParam}}
         {{^isFile}}
-        formParams[ U("{{baseName}}") ] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
         {{/isFile}}
         {{/isFormParam}}
         {{/isContainer}}
         {{^isContainer}}
         {{#isQueryParam}}
-        queryParams[U("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
+        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
         {{/isQueryParam}}
         {{#isHeaderParam}}
-        headerParams[U("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
+        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
         {{/isHeaderParam}}
         {{#isFormParam}}
         {{#isFile}}
-        fileParams[ U("{{baseName}}") ] = {{paramName}};
+        fileParams[ utility::conversions::to_string_t("{{baseName}}") ] = {{paramName}};
         {{/isFile}}
         {{^isFile}}
-        formParams[ U("{{baseName}}") ] = ApiClient::parameterToString({{paramName}});
+        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToString({{paramName}});
         {{/isFile}}
         {{/isFormParam}}
         {{/isContainer}}
@@ -144,9 +144,9 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         {{#bodyParam}}
         web::json::value json;
 
@@ -177,9 +177,9 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         {{/bodyParam}}
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         {{#bodyParam}}
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
         {{#isPrimitiveType}}
@@ -197,28 +197,28 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
                 {{/items.isDateTime}}{{^items.isDateTime}}jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
                 {{/items.isDateTime}}{{/items.isString}}{{/items.isPrimitiveType}}
             }
-            multipart->add(ModelBase::toHttpContent(U("{{paramName}}"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
         {{/isListContainer}}
         {{^isListContainer}}
-        {{#isString}}multipart->add(ModelBase::toHttpContent(U("{{paramName}}"), {{paramName}}));
+        {{#isString}}multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), {{paramName}}));
         {{/isString}}
         {{^isString}}
         if({{paramName}}.get())
         {
-            {{paramName}}->toMultipart(multipart, U("{{paramName}}"));
+            {{paramName}}->toMultipart(multipart, utility::conversions::to_string_t("{{paramName}}"));
         }
         {{/isString}}
         {{/isListContainer}}
         {{/isPrimitiveType}}
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
         {{/bodyParam}}
     }
     else
     {
-        throw ApiException(415, U("{{classname}}->{{operationId}} does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("{{classname}}->{{operationId}} does not consume any supported media type"));
     }
 
     {{#authMethods}}
@@ -226,19 +226,19 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{#isApiKey}}
     {{#isKeyInHeader}}
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(U("{{keyParamName}}"));
+        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
         if ( apiKey.size() > 0 )
         {
-            headerParams[U("{{keyParamName}}")] = apiKey;
+            headerParams[utility::conversions::to_string_t("{{keyParamName}}")] = apiKey;
         }
     }
     {{/isKeyInHeader}}
     {{#isKeyInQuery}}
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(U("{{keyParamName}}"));
+        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
         if ( apiKey.size() > 0 )
         {
-            queryParams[U("{{keyParamName}}")] = apiKey;
+            queryParams[utility::conversions::to_string_t("{{keyParamName}}")] = apiKey;
         }
     }
     {{/isKeyInQuery}}
@@ -251,7 +251,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{/isOAuth}}
     {{/authMethods}}
 
-    return m_ApiClient->callApi(path, U("{{httpMethod}}"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("{{httpMethod}}"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -262,18 +262,18 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling {{operationId}}: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling {{operationId}}: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling {{operationId}}: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling {{operationId}}: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -304,7 +304,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         {{{returnType}}} result({{{defaultResponse}}});
         {{/returnContainer}}
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
@@ -330,18 +330,18 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
             {{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.isString}}result = ModelBase::stringFromJson(json);
             {{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}result->fromJson(json);{{/vendorExtensions.x-codegen-response.isString}}{{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{/isMapContainer}}{{/isListContainer}}
         }{{#vendorExtensions.x-codegen-response.isString}}
-        else if(responseHttpContentType == U("text/plain"))
+        else if(responseHttpContentType == utility::conversions::to_string_t("text/plain"))
         {
             result = response;
         }{{/vendorExtensions.x-codegen-response.isString}}
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling {{operationId}}: unsupported response type"));
+                , utility::conversions::to_string_t("error calling {{operationId}}: unsupported response type"));
         }
 
         return result;

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
@@ -48,7 +48,7 @@ public:
 
         for( size_t i = 0; i < value.size(); i++)
         {
-            if( i > 0) ss << U(", ");
+            if( i > 0) ss << utility::conversions::to_string_t(", ");
             ss << ApiClient::parameterToString(value[i]);
         }
 

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
@@ -67,17 +67,17 @@ pplx::task<web::http::http_response> ApiClient::callApi(
 {
     if (postBody != nullptr && formParams.size() != 0)
     {
-        throw ApiException(400, U("Cannot have body and form params"));
+        throw ApiException(400, utility::conversions::to_string_t("Cannot have body and form params"));
     }
 
     if (postBody != nullptr && fileParams.size() != 0)
     {
-        throw ApiException(400, U("Cannot have body and file params"));
+        throw ApiException(400, utility::conversions::to_string_t("Cannot have body and file params"));
     }
 
-    if (fileParams.size() > 0 && contentType != U("multipart/form-data"))
+    if (fileParams.size() > 0 && contentType != utility::conversions::to_string_t("multipart/form-data"))
     {
-        throw ApiException(400, U("Operations with file parameters must be called with multipart/form-data"));
+        throw ApiException(400, utility::conversions::to_string_t("Operations with file parameters must be called with multipart/form-data"));
     }
 
     web::http::client::http_client client(m_Configuration->getBaseUrl(), m_Configuration->getHttpConfig());
@@ -103,7 +103,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
         uploadData.writeTo(data);
         auto bodyString = data.str();
         auto length = bodyString.size();
-        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, U("multipart/form-data; boundary=") + uploadData.getBoundary());
+        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, utility::conversions::to_string_t("multipart/form-data; boundary=") + uploadData.getBoundary());
     }
     else
     {
@@ -117,7 +117,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
         }
         else
         {
-            if (contentType == U("application/json"))
+            if (contentType == utility::conversions::to_string_t("application/json"))
             {
                 web::json::value body_data = web::json::value::object();
                 for (auto& kvp : formParams)
@@ -138,7 +138,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
                 }
                 if (!formParams.empty())
                 {
-                    request.set_body(formData.query(), U("application/x-www-form-urlencoded"));
+                    request.set_body(formData.query(), utility::conversions::to_string_t("application/x-www-form-urlencoded"));
                 }
             }
         }

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-source.mustache
@@ -55,7 +55,7 @@ utility::string_t ApiConfiguration::getApiKey( const utility::string_t& prefix) 
     {
         return result->second;
     }
-    return U("");
+    return utility::conversions::to_string_t("");
 }
 
 void ApiConfiguration::setApiKey( const utility::string_t& prefix, const utility::string_t& apiKey )

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
@@ -57,11 +57,11 @@ web::json::value {{classname}}::toJson() const
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+        val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     }
     {{/required}}
     {{#required}}
-    val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+    val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     {{/required}}
     {{/isMapContainer}}
     {{/isListContainer}}
@@ -74,12 +74,12 @@ web::json::value {{classname}}::toJson() const
             jsonArray.push_back(ModelBase::toJson(item));
         }
         {{#required}}
-        val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+        val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         {{/required}}
         {{^required}}
         if(jsonArray.size() > 0)
         {
-            val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+            val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         }
         {{/required}}
     }
@@ -90,17 +90,17 @@ web::json::value {{classname}}::toJson() const
         for( auto& item : m_{{name}} )
         {
             web::json::value tmp = web::json::value::object();
-            tmp[U("key")] = ModelBase::toJson(item.first);
-            tmp[U("value")] = ModelBase::toJson(item.second);
+            tmp[utility::conversions::to_string_t("key")] = ModelBase::toJson(item.first);
+            tmp[utility::conversions::to_string_t("value")] = ModelBase::toJson(item.second);
             jsonArray.push_back(tmp);
         }
         {{#required}}
-        val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+        val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         {{/required}}
         {{^required}}
         if(jsonArray.size() > 0)
         {
-            val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+            val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         }
         {{/required}}
     }
@@ -111,11 +111,11 @@ web::json::value {{classname}}::toJson() const
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+        val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     }
     {{/required}}
     {{#required}}
-    val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+    val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     {{/required}}
     {{/isPrimitiveType}}
     {{/isMapContainer}}
@@ -138,13 +138,13 @@ void {{classname}}::fromJson(web::json::value& val)
     {{^isListContainer}}
     {{^isMapContainer}}
     {{^required}}
-    if(val.has_field(U("{{baseName}}")))
+    if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
     {
-        {{setter}}(ModelBase::{{baseType}}FromJson(val[U("{{baseName}}")]));
+        {{setter}}(ModelBase::{{baseType}}FromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     }
     {{/required}}
     {{#required}}
-    {{setter}}(ModelBase::{{baseType}}FromJson(val[U("{{baseName}}")]));
+    {{setter}}(ModelBase::{{baseType}}FromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/required}}
     {{/isMapContainer}}
     {{/isListContainer}}
@@ -154,10 +154,10 @@ void {{classname}}::fromJson(web::json::value& val)
         m_{{name}}.clear();
         std::vector<web::json::value> jsonArray;
         {{^required}}
-        if(val.has_field(U("{{baseName}}")))
+        if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
-        for( auto& item : val[U("{{baseName}}")].as_array() )
+        for( auto& item : val[utility::conversions::to_string_t("{{baseName}}")].as_array() )
         {
             {{#items.isPrimitiveType}}
             m_{{name}}.push_back(ModelBase::{{items.baseType}}FromJson(item));
@@ -195,26 +195,26 @@ void {{classname}}::fromJson(web::json::value& val)
         m_{{name}}.clear();
         std::vector<web::json::value> jsonArray;
         {{^required}}
-        if(val.has_field(U("{{baseName}}")))
+        if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
-        for( auto& item : val[U("{{baseName}}")].as_array() )
+        for( auto& item : val[utility::conversions::to_string_t("{{baseName}}")].as_array() )
         {  
             utility::string_t key;
-            if(item.has_field(U("key")))
+            if(item.has_field(utility::conversions::to_string_t("key")))
             {
-                key = ModelBase::stringFromJson(item[U("key")]);
+                key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
             }
             {{#items.isPrimitiveType}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isPrimitiveType}}
             {{^items.isPrimitiveType}}
             {{#items.isString}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isString}}
             {{^items.isString}}
             {{#items.isDateTime}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isDateTime}}
             {{^items.isDateTime}}
             if(item.is_null())
@@ -224,7 +224,7 @@ void {{classname}}::fromJson(web::json::value& val)
             else
             {
                 {{{items.datatype}}} newItem({{{items.defaultValue}}});
-                newItem->fromJson(item[U("value")]);
+                newItem->fromJson(item[utility::conversions::to_string_t("value")]);
                 m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
             }
             {{/items.isDateTime}}
@@ -240,20 +240,20 @@ void {{classname}}::fromJson(web::json::value& val)
     {{^isMapContainer}}
     {{^isPrimitiveType}}
     {{^required}}
-    if(val.has_field(U("{{baseName}}")))
+    if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
     {
         {{#isString}}
-        {{setter}}(ModelBase::stringFromJson(val[U("{{baseName}}")]));
+        {{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
         {{/isString}}
         {{^isString}}
         {{#isDateTime}}
-        {{setter}}(ModelBase::dateFromJson(val[U("{{baseName}}")]));
+        {{setter}}(ModelBase::dateFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
         {{/isDateTime}}
         {{^isDateTime}}
-        if(!val[U("{{baseName}}")].is_null())
+        if(!val[utility::conversions::to_string_t("{{baseName}}")].is_null())
         {
             {{{datatype}}} newItem({{{defaultValue}}});
-            newItem->fromJson(val[U("{{baseName}}")]);
+            newItem->fromJson(val[utility::conversions::to_string_t("{{baseName}}")]);
             {{setter}}( newItem );
         }
         {{/isDateTime}}
@@ -262,20 +262,20 @@ void {{classname}}::fromJson(web::json::value& val)
     {{/required}}
     {{#required}}
     {{#isString}}
-    {{setter}}(ModelBase::stringFromJson(val[U("{{baseName}}")]));
+    {{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/isString}}
     {{^isString}}
     {{#isDateTime}}
     {{setter}}
-    (ModelBase::dateFromJson(val[U("{{baseName}}")]));
+    (ModelBase::dateFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/isDateTime}}
     {{^isDateTime}}
     {{#vendorExtensions.x-codegen-file}}
-    {{setter}}(ModelBase::fileFromJson(val[U("{{baseName}}")]));
+    {{setter}}(ModelBase::fileFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/vendorExtensions.x-codegen-file}}
     {{^vendorExtensions.x-codegen-file}}
     {{{datatype}}} new{{name}}({{{defaultValue}}});
-    new{{name}}->fromJson(val[U("{{baseName}}")]);
+    new{{name}}->fromJson(val[utility::conversions::to_string_t("{{baseName}}")]);
     {{setter}}( new{{name}} );
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}
@@ -291,9 +291,9 @@ void {{classname}}::fromJson(web::json::value& val)
 void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     {{#vars}}
@@ -303,11 +303,11 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     }
     {{/required}}
     {{#required}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/required}}
     {{/isListContainer}}
     {{/isMapContainer}}
@@ -319,11 +319,11 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
         {
             jsonArray.push_back(ModelBase::toJson(item));
         }
-        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         {{/required}}{{^required}}
         if(jsonArray.size() > 0)
         {
-            multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
         {{/required}}
     }
@@ -334,15 +334,15 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
         for( auto& item : m_{{name}} )
         {
             web::json::value tmp = web::json::value::object();
-            tmp[U("key")] = ModelBase::toJson(item.first);
-            tmp[U("value")] = ModelBase::toJson(item.second);
+            tmp[utility::conversions::to_string_t("key")] = ModelBase::toJson(item.first);
+            tmp[utility::conversions::to_string_t("value")] = ModelBase::toJson(item.second);
             jsonArray.push_back(tmp);
         }
-        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         {{/required}}{{^required}}
         if(jsonArray.size() > 0)
         {
-            multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
         {{/required}}
     }
@@ -353,29 +353,29 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        {{#isString}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
-        {{/isString}}{{^isString}}{{#isDateTime}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+        {{#isString}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
+        {{/isString}}{{^isString}}{{#isDateTime}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
         {{/isDateTime}}{{^isDateTime}}if (m_{{name}}.get())
         {
-            m_{{name}}->toMultipart(multipart, U("{{baseName}}."));
+            m_{{name}}->toMultipart(multipart, utility::conversions::to_string_t("{{baseName}}."));
         }
         {{/isDateTime}}{{/isString}}
     }
     {{/required}}
     {{#required}}
     {{#isString}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/isString}}
     {{^isString}}
     {{#isDateTime}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/isDateTime}}
     {{^isDateTime}}
     {{#vendorExtensions.x-codegen-file}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/vendorExtensions.x-codegen-file}}
     {{^vendorExtensions.x-codegen-file}}
-    m_{{name}}->toMultipart(multipart, U("{{baseName}}."));
+    m_{{name}}->toMultipart(multipart, utility::conversions::to_string_t("{{baseName}}."));
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}
     {{/isString}}
@@ -389,9 +389,9 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
 void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     {{#vars}}
@@ -399,13 +399,13 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{^isListContainer}}
     {{^isMapContainer}}
     {{^required}}
-    if(multipart->hasContent(U("{{baseName}}")))
+    if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
     {
-        {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     }
     {{/required}}
     {{#required}}
-    {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(U("{{baseName}}"))));
+    {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     {{/required}}
     {{/isMapContainer}}
     {{/isListContainer}}
@@ -414,11 +414,11 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {
         m_{{name}}.clear();
         {{^required}}
-        if(multipart->hasContent(U("{{baseName}}")))
+        if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
 
-        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         for( auto& item : jsonArray.as_array() )
         {
             {{#isPrimitiveType}}
@@ -456,28 +456,28 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {
         m_{{name}}.clear();
         {{^required}}
-        if(multipart->hasContent(U("{{baseName}}")))
+        if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
 
-        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         for( auto& item : jsonArray.as_array() )
         {
             utility::string_t key;
-            if(item.has_field(U("key")))
+            if(item.has_field(utility::conversions::to_string_t("key")))
             {
-                key = ModelBase::stringFromJson(item[U("key")]);
+                key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
             }
             {{#items.isPrimitiveType}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isPrimitiveType}}
             {{^items.isPrimitiveType}}
             {{#items.isString}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isString}}
             {{^items.isString}}
             {{#items.isDateTime}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isDateTime}}
             {{^items.isDateTime}}
             if(item.is_null())
@@ -487,7 +487,7 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
             else
             {
                 {{{items.datatype}}} newItem({{{items.defaultValue}}});
-                newItem->fromJson(item[U("value")]);
+                newItem->fromJson(item[utility::conversions::to_string_t("value")]);
                 m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
             }
             {{/items.isDateTime}}
@@ -503,20 +503,20 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{^isMapContainer}}
     {{^isPrimitiveType}}
     {{^required}}
-    if(multipart->hasContent(U("{{baseName}}")))
+    if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
     {
         {{#isString}}
-        {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         {{/isString}}
         {{^isString}}
         {{#isDateTime}}
-        {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         {{/isDateTime}}
         {{^isDateTime}}
-        if(multipart->hasContent(U("{{baseName}}")))
+        if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
         {
             {{{datatype}}} newItem({{{defaultValue}}});
-            newItem->fromMultiPart(multipart, U("{{baseName}}."));
+            newItem->fromMultiPart(multipart, utility::conversions::to_string_t("{{baseName}}."));
             {{setter}}( newItem );
         }
         {{/isDateTime}}
@@ -525,19 +525,19 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{/required}}
     {{#required}}
     {{#isString}}
-    {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+    {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     {{/isString}}
     {{^isString}}
     {{#isDateTime}}
-    {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+    {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     {{/isDateTime}}
     {{^isDateTime}}
     {{#vendorExtensions.x-codegen-file}}
-    {{setter}}(multipart->getContent(U("{{baseName}}")));
+    {{setter}}(multipart->getContent(utility::conversions::to_string_t("{{baseName}}")));
     {{/vendorExtensions.x-codegen-file}}
     {{^vendorExtensions.x-codegen-file}}
     {{{datatype}}} new{{name}}({{{defaultValue}}});
-    new{{name}}->fromMultiPart(multipart, U("{{baseName}}."));
+    new{{name}}->fromMultiPart(multipart, utility::conversions::to_string_t("{{baseName}}."));
     {{setter}}( new{{name}} );
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
@@ -51,13 +51,13 @@ public:
     static bool boolFromJson(web::json::value& val);
     static std::shared_ptr<HttpContent> fileFromJson(web::json::value& val);
 
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::string_t& value, const utility::string_t& contentType = U(""));
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::datetime& value, const utility::string_t& contentType = U(""));
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::string_t& value, const utility::string_t& contentType = utility::conversions::to_string_t(""));
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::datetime& value, const utility::string_t& contentType = utility::conversions::to_string_t(""));
     static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, std::shared_ptr<HttpContent> value );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const web::json::value& value, const utility::string_t& contentType = U("application/json") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int32_t value, const utility::string_t& contentType = U("") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int64_t value, const utility::string_t& contentType = U("") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, double value, const utility::string_t& contentType = U("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const web::json::value& value, const utility::string_t& contentType = utility::conversions::to_string_t("application/json") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int32_t value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int64_t value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, double value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
 
     static int64_t int64_tFromHttpContent(std::shared_ptr<HttpContent> val);
     static int32_t int32_tFromHttpContent(std::shared_ptr<HttpContent> val);

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-source.mustache
@@ -39,10 +39,10 @@ web::json::value ModelBase::toJson(bool value) {
 web::json::value ModelBase::toJson( std::shared_ptr<HttpContent> content )
 {
     web::json::value value;
-    value[U("ContentDisposition")] = ModelBase::toJson(content->getContentDisposition());
-    value[U("ContentType")] = ModelBase::toJson(content->getContentType());
-    value[U("FileName")] = ModelBase::toJson(content->getFileName());
-    value[U("InputStream")] = web::json::value::string( ModelBase::toBase64(content->getData()) );
+    value[utility::conversions::to_string_t("ContentDisposition")] = ModelBase::toJson(content->getContentDisposition());
+    value[utility::conversions::to_string_t("ContentType")] = ModelBase::toJson(content->getContentType());
+    value[utility::conversions::to_string_t("FileName")] = ModelBase::toJson(content->getFileName());
+    value[utility::conversions::to_string_t("InputStream")] = web::json::value::string( ModelBase::toBase64(content->getData()) );
     return value;
 }
 
@@ -50,21 +50,21 @@ std::shared_ptr<HttpContent> ModelBase::fileFromJson(web::json::value& val)
 {
     std::shared_ptr<HttpContent> content(new HttpContent);
 
-    if(val.has_field(U("ContentDisposition")))
+    if(val.has_field(utility::conversions::to_string_t("ContentDisposition")))
     {
-        content->setContentDisposition( ModelBase::stringFromJson(val[U("ContentDisposition")]) );
+        content->setContentDisposition( ModelBase::stringFromJson(val[utility::conversions::to_string_t("ContentDisposition")]) );
     }
-    if(val.has_field(U("ContentType")))
+    if(val.has_field(utility::conversions::to_string_t("ContentType")))
     {
-        content->setContentType( ModelBase::stringFromJson(val[U("ContentType")]) );
+        content->setContentType( ModelBase::stringFromJson(val[utility::conversions::to_string_t("ContentType")]) );
     }
-    if(val.has_field(U("FileName")))
+    if(val.has_field(utility::conversions::to_string_t("FileName")))
     {
-        content->setFileName( ModelBase::stringFromJson(val[U("FileName")]) );
+        content->setFileName( ModelBase::stringFromJson(val[utility::conversions::to_string_t("FileName")]) );
     }
-    if(val.has_field(U("InputStream")))
+    if(val.has_field(utility::conversions::to_string_t("InputStream")))
     {
-        content->setData( ModelBase::fromBase64( ModelBase::stringFromJson(val[U("InputStream")]) ) );
+        content->setData( ModelBase::fromBase64( ModelBase::stringFromJson(val[utility::conversions::to_string_t("InputStream")]) ) );
     }
 
     return content;
@@ -79,7 +79,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content(new HttpContent);
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value) ) ) );
     return content;
@@ -88,7 +88,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value.to_string(utility::datetime::ISO_8601) ) ) ) );
     return content;
@@ -107,7 +107,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value.serialize()) ) ) );
     return content;
@@ -116,7 +116,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -127,7 +127,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -138,7 +138,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -244,12 +244,12 @@ std::shared_ptr<std::istream> ModelBase::fromBase64( const utility::string_t& en
                         result->write( outBuf, 1 );
                         return result;
                     default:
-                        throw web::json::json_exception( U( "Invalid Padding in Base 64!" ) );
+                        throw web::json::json_exception( utility::conversions::to_string_t( "Invalid Padding in Base 64!" ).c_str() );
                 }
             }
             else
             {
-                throw web::json::json_exception( U( "Non-Valid Character in Base 64!" ) );
+                throw web::json::json_exception( utility::conversions::to_string_t( "Non-Valid Character in Base 64!" ).c_str() );
             }
             ++cursor;
         }
@@ -277,7 +277,7 @@ float ModelBase::floatFromJson(web::json::value& val)
 }
 utility::string_t ModelBase::stringFromJson(web::json::value& val)
 {
-    return val.is_string() ? val.as_string() : U("");
+    return val.is_string() ? val.as_string() : utility::conversions::to_string_t("");
 }
 
 utility::datetime ModelBase::dateFromJson(web::json::value& val)


### PR DESCRIPTION
This PR removes all usages of the infamous casablanca `U(x)` macro, and replaces them with a safer conversion function (also provided by casablanca).
The rationale for this change is that users of the generator might need to disable that macro entirely in casablanca, as it can easily cause conflicts (see [the Casablanca FAQ](https://github.com/Microsoft/cpprestsdk/wiki/FAQ#what-is-utilitystring_t-and-the-u-macro) for more info).