### PR TITLE
[CppRest] Generate unique header guards based on the package names.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -179,8 +179,10 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
 
         additionalProperties.put("modelNamespaceDeclarations", modelPackage.split("\\."));
         additionalProperties.put("modelNamespace", modelPackage.replaceAll("\\.", "::"));
+        additionalProperties.put("modelHeaderGuardPrefix", modelPackage.replaceAll("\\.", "_").toUpperCase());
         additionalProperties.put("apiNamespaceDeclarations", apiPackage.split("\\."));
         additionalProperties.put("apiNamespace", apiPackage.replaceAll("\\.", "::"));
+        additionalProperties.put("apiHeaderGuardPrefix", apiPackage.replaceAll("\\.", "_").toUpperCase());
         additionalProperties.put("declspec", declspec);
         additionalProperties.put("defaultInclude", defaultInclude);
     }

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
@@ -5,8 +5,8 @@
  * {{description}}
  */
 
-#ifndef {{classname}}_H_
-#define {{classname}}_H_
+#ifndef {{apiHeaderGuardPrefix}}_{{classname}}_H_
+#define {{apiHeaderGuardPrefix}}_{{classname}}_H_
 
 {{{defaultInclude}}}
 #include "ApiClient.h"
@@ -44,6 +44,6 @@ protected:
 }
 {{/apiNamespaceDeclarations}}
 
-#endif /* {{classname}}_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_{{classname}}_H_ */
 
 {{/operations}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
@@ -5,8 +5,8 @@
  * This is an API client responsible for stating the HTTP calls
  */
 
-#ifndef ApiClient_H_
-#define ApiClient_H_
+#ifndef {{apiHeaderGuardPrefix}}_ApiClient_H_
+#define {{apiHeaderGuardPrefix}}_ApiClient_H_
 
 {{{defaultInclude}}}
 #include "ApiConfiguration.h"
@@ -75,4 +75,4 @@ protected:
 }
 {{/apiNamespaceDeclarations}}
 
-#endif /* ApiClient_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_ApiClient_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-header.mustache
@@ -5,8 +5,8 @@
  * This class represents a single item of a multipart-formdata request.
  */
 
-#ifndef ApiConfiguration_H_
-#define ApiConfiguration_H_
+#ifndef {{apiHeaderGuardPrefix}}_ApiConfiguration_H_
+#define {{apiHeaderGuardPrefix}}_ApiConfiguration_H_
 
 {{{defaultInclude}}}
 
@@ -49,4 +49,4 @@ protected:
 {{#apiNamespaceDeclarations}}
 }
 {{/apiNamespaceDeclarations}}
-#endif /* ApiConfiguration_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_ApiConfiguration_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiexception-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiexception-header.mustache
@@ -5,8 +5,8 @@
  * This is the exception being thrown in case the api call was not successful
  */
 
-#ifndef ApiException_H_
-#define ApiException_H_
+#ifndef {{apiHeaderGuardPrefix}}_ApiException_H_
+#define {{apiHeaderGuardPrefix}}_ApiException_H_
 
 {{{defaultInclude}}}
 
@@ -46,4 +46,4 @@ protected:
 }
 {{/apiNamespaceDeclarations}}
 
-#endif /* ApiBase_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_ApiBase_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/httpcontent-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/httpcontent-header.mustache
@@ -5,8 +5,8 @@
  * This class represents a single item of a multipart-formdata request.
  */
 
-#ifndef HttpContent_H_
-#define HttpContent_H_
+#ifndef {{modelHeaderGuardPrefix}}_HttpContent_H_
+#define {{modelHeaderGuardPrefix}}_HttpContent_H_
 
 {{{defaultInclude}}}
 
@@ -54,4 +54,4 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* HttpContent_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_HttpContent_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/ihttpbody-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/ihttpbody-header.mustache
@@ -5,8 +5,8 @@
  * This is the interface for contents that can be sent to a remote HTTP server.
  */
 
-#ifndef IHttpBody_H_
-#define IHttpBody_H_
+#ifndef {{modelHeaderGuardPrefix}}_IHttpBody_H_
+#define {{modelHeaderGuardPrefix}}_IHttpBody_H_
 
 {{{defaultInclude}}}
 #include <iostream>
@@ -27,4 +27,4 @@ public:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* IHttpBody_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_IHttpBody_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/jsonbody-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/jsonbody-header.mustache
@@ -5,8 +5,8 @@
  * This is a JSON http body which can be submitted via http
  */
 
-#ifndef JsonBody_H_
-#define JsonBody_H_
+#ifndef {{modelHeaderGuardPrefix}}_JsonBody_H_
+#define {{modelHeaderGuardPrefix}}_JsonBody_H_
 
 {{{defaultInclude}}}
 #include "IHttpBody.h"
@@ -34,4 +34,4 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* JsonBody_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_JsonBody_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
@@ -5,8 +5,8 @@
  * {{description}}
  */
 
-#ifndef {{classname}}_H_
-#define {{classname}}_H_
+#ifndef {{modelHeaderGuardPrefix}}_{{classname}}_H_
+#define {{modelHeaderGuardPrefix}}_{{classname}}_H_
 
 {{^parent}}
 {{{defaultInclude}}}
@@ -72,6 +72,6 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* {{classname}}_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_{{classname}}_H_ */
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
@@ -5,8 +5,8 @@
  * This is the base class for all model classes
  */
 
-#ifndef ModelBase_H_
-#define ModelBase_H_
+#ifndef {{modelHeaderGuardPrefix}}_ModelBase_H_
+#define {{modelHeaderGuardPrefix}}_ModelBase_H_
 
 {{{defaultInclude}}}
 #include "HttpContent.h"
@@ -77,4 +77,4 @@ public:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* ModelBase_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_ModelBase_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/multipart-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/multipart-header.mustache
@@ -5,8 +5,8 @@
  * This class represents a container for building a application/x-multipart-formdata requests.
  */
 
-#ifndef MultipartFormData_H_
-#define MultipartFormData_H_
+#ifndef {{modelHeaderGuardPrefix}}_MultipartFormData_H_
+#define {{modelHeaderGuardPrefix}}_MultipartFormData_H_
 
 {{{defaultInclude}}}
 #include "IHttpBody.h"
@@ -47,4 +47,4 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* MultipartFormData_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_MultipartFormData_H_ */


### PR DESCRIPTION
This PR includes package names in the generated header guards, in order to avoid clashes when generating code from two or more different API spec files.