### PR TITLE
Feature/cpprest fix modelbase includes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -143,7 +143,7 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
         typeMapping.put("array", "std::vector");
         typeMapping.put("map", "std::map");
         typeMapping.put("file", "HttpContent");
-        typeMapping.put("object", "Object");
+        typeMapping.put("object", "ModelBase");
         typeMapping.put("binary", "std::string");
         typeMapping.put("number", "double");
         typeMapping.put("UUID", "utility::string_t");
@@ -153,7 +153,7 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
         importMapping.put("std::map", "#include <map>");
         importMapping.put("std::string", "#include <string>");
         importMapping.put("HttpContent", "#include \"HttpContent.h\"");
-        importMapping.put("Object", "#include \"Object.h\"");
+        importMapping.put("ModelBase", "#include \"ModelBase.h\"");
         importMapping.put("utility::string_t", "#include <cpprest/details/basic_types.h>");
         importMapping.put("utility::datetime", "#include <cpprest/details/basic_types.h>");
     }

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
@@ -9,7 +9,7 @@
 #define {{apiHeaderGuardPrefix}}_{{classname}}_H_
 
 {{{defaultInclude}}}
-#include "ApiClient.h"
+#include "../ApiClient.h"
 
 {{#imports}}{{{import}}}
 {{/imports}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
@@ -10,7 +10,7 @@
 
 {{^parent}}
 {{{defaultInclude}}}
-#include "ModelBase.h"
+#include "../ModelBase.h"
 {{/parent}}
 
 {{#imports}}{{{this}}}


### PR DESCRIPTION
1. The `Object.h` header file does not exist, we replace it with `ModelBase.h` which provides the expected functionality.
2. Fixed some relative include paths, to prevent clashes during linking when using two separate APIs that generate identical file names.