### PR TITLE
[cpprest] Make the generated APIs mockable.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -45,7 +45,6 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
 
     public static final String DECLSPEC = "declspec";
     public static final String DEFAULT_INCLUDE = "defaultInclude";
-    public static final String GENERATE_INTERFACES_FOR_APIS = "generateInterfacesForApis";
     public static final String GENERATE_GMOCKS_FOR_APIS = "generateGMocksForApis";
 
     protected String packageVersion = "1.0.0";
@@ -112,8 +111,6 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
         addOption(DEFAULT_INCLUDE,
                 "The default include statement that should be placed in all headers for including things like the declspec (convention: #include \"Commons.h\" ",
                 this.defaultInclude);
-        addOption(GENERATE_INTERFACES_FOR_APIS,
-                "Generate abstract base classes (interfaces) for APIs. This allows to mocks APIs (e.g. for unit testing).");
         addOption(GENERATE_GMOCKS_FOR_APIS,
                 "Generate Google Mock classes for APIs. Implies generating abstract base classes (interfaces) for APIs.");
 
@@ -180,7 +177,6 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
 
         if (convertPropertyToBoolean(GENERATE_GMOCKS_FOR_APIS))
         {
-            additionalProperties.put(GENERATE_INTERFACES_FOR_APIS, "true");
             apiTemplateFiles.put("api-gmock.mustache", "GMock.h");
         }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -45,6 +45,8 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
 
     public static final String DECLSPEC = "declspec";
     public static final String DEFAULT_INCLUDE = "defaultInclude";
+    public static final String GENERATE_INTERFACES_FOR_APIS = "generateInterfacesForApis";
+    public static final String GENERATE_GMOCKS_FOR_APIS = "generateGMocksForApis";
 
     protected String packageVersion = "1.0.0";
     protected String declspec = "";
@@ -110,6 +112,10 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
         addOption(DEFAULT_INCLUDE,
                 "The default include statement that should be placed in all headers for including things like the declspec (convention: #include \"Commons.h\" ",
                 this.defaultInclude);
+        addOption(GENERATE_INTERFACES_FOR_APIS,
+                "Generate abstract base classes (interfaces) for APIs. This allows to mocks APIs (e.g. for unit testing).");
+        addOption(GENERATE_GMOCKS_FOR_APIS,
+                "Generate Google Mock classes for APIs. Implies generating abstract base classes (interfaces) for APIs.");
 
         supportingFiles.add(new SupportingFile("modelbase-header.mustache", "", "ModelBase.h"));
         supportingFiles.add(new SupportingFile("modelbase-source.mustache", "", "ModelBase.cpp"));
@@ -170,6 +176,12 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
 
         if (additionalProperties.containsKey(DEFAULT_INCLUDE)) {
             defaultInclude = additionalProperties.get(DEFAULT_INCLUDE).toString();
+        }
+
+        if (convertPropertyToBoolean(GENERATE_GMOCKS_FOR_APIS))
+        {
+            additionalProperties.put(GENERATE_INTERFACES_FOR_APIS, "true");
+            apiTemplateFiles.put("api-gmock.mustache", "GMock.h");
         }
 
         additionalProperties.put("modelNamespaceDeclarations", modelPackage.split("\\."));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -111,8 +111,7 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
         addOption(DEFAULT_INCLUDE,
                 "The default include statement that should be placed in all headers for including things like the declspec (convention: #include \"Commons.h\" ",
                 this.defaultInclude);
-        addOption(GENERATE_GMOCKS_FOR_APIS,
-                "Generate Google Mock classes for APIs. Implies generating abstract base classes (interfaces) for APIs.");
+        addOption(GENERATE_GMOCKS_FOR_APIS, "Generate Google Mock classes for APIs.");
 
         supportingFiles.add(new SupportingFile("modelbase-header.mustache", "", "ModelBase.h"));
         supportingFiles.add(new SupportingFile("modelbase-source.mustache", "", "ModelBase.cpp"));

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-gmock.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-gmock.mustache
@@ -1,0 +1,35 @@
+{{>licenseInfo}}
+{{#operations}}
+#ifndef {{apiHeaderGuardPrefix}}_{{classname}}GMock_H_
+#define {{apiHeaderGuardPrefix}}_{{classname}}GMock_H_
+
+#include <gmock/gmock.h>
+
+#include "{{classname}}.h"
+
+{{#apiNamespaceDeclarations}}
+namespace {{this}} {
+{{/apiNamespaceDeclarations}}
+
+using namespace {{modelNamespace}};
+
+
+class {{declspec}} {{classname}}Mock : public I{{classname}}
+{
+public:
+    {{#operation}}
+    MOCK_METHOD{{allParams.size}}( {{operationId}}, pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> (
+        {{#allParams}}
+        {{^required}}boost::optional<{{/required}}{{{dataType}}}{{^required}}>{{/required}}{{#hasMore}},{{/hasMore}}
+        {{/allParams}}
+    ) );
+    {{/operation}}
+};
+
+{{#apiNamespaceDeclarations}}
+}
+{{/apiNamespaceDeclarations}}
+
+#endif /* {{apiHeaderGuardPrefix}}_{{classname}}GMock_H_ */
+
+{{/operations}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
@@ -22,7 +22,23 @@ namespace {{this}} {
 
 using namespace {{modelNamespace}};
 
-class {{declspec}} {{classname}}
+{{#generateInterfacesForApis}}
+class {{declspec}} I{{classname}}
+{
+public:
+    virtual ~I{{classname}}() = default;
+    {{#operation}}
+    virtual pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {{operationId}}(
+        {{#allParams}}
+        {{^required}}boost::optional<{{/required}}{{{dataType}}}{{^required}}>{{/required}} {{paramName}}{{#hasMore}},{{/hasMore}}
+        {{/allParams}}
+    ) = 0;
+    {{/operation}}
+};
+
+{{/generateInterfacesForApis}}
+
+class {{declspec}} {{classname}} {{#generateInterfacesForApis}}: public I{{classname}}{{/generateInterfacesForApis}}
 {
 public:
     {{classname}}( std::shared_ptr<ApiClient> apiClient );
@@ -41,7 +57,7 @@ public:
         {{#allParams}}
         {{^required}}boost::optional<{{/required}}{{{dataType}}}{{^required}}>{{/required}} {{paramName}}{{#hasMore}},{{/hasMore}}
         {{/allParams}}
-    );
+    ){{#generateInterfacesForApis}} override{{/generateInterfacesForApis}};
     {{/operation}}
 
 protected:

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
@@ -22,7 +22,6 @@ namespace {{this}} {
 
 using namespace {{modelNamespace}};
 
-{{#generateInterfacesForApis}}
 class {{declspec}} I{{classname}}
 {
 public:
@@ -36,13 +35,12 @@ public:
     {{/operation}}
 };
 
-{{/generateInterfacesForApis}}
 
-class {{declspec}} {{classname}} {{#generateInterfacesForApis}}: public I{{classname}}{{/generateInterfacesForApis}}
+class {{declspec}} {{classname}} : public I{{classname}}
 {
 public:
     {{classname}}( std::shared_ptr<ApiClient> apiClient );
-    virtual ~{{classname}}();
+    ~{{classname}}() override;
     {{#operation}}
     /// <summary>
     /// {{summary}}
@@ -57,7 +55,7 @@ public:
         {{#allParams}}
         {{^required}}boost::optional<{{/required}}{{{dataType}}}{{^required}}>{{/required}} {{paramName}}{{#hasMore}},{{/hasMore}}
         {{/allParams}}
-    ){{#generateInterfacesForApis}} override{{/generateInterfacesForApis}};
+    ) override;
     {{/operation}}
 
 protected:

--- a/samples/client/petstore/cpprest/api/PetApi.h
+++ b/samples/client/petstore/cpprest/api/PetApi.h
@@ -36,7 +36,8 @@ namespace api {
 
 using namespace io::swagger::client::model;
 
-class  PetApi
+
+class  PetApi 
 {
 public:
     PetApi( std::shared_ptr<ApiClient> apiClient );

--- a/samples/client/petstore/cpprest/api/PetApi.h
+++ b/samples/client/petstore/cpprest/api/PetApi.h
@@ -36,12 +36,47 @@ namespace api {
 
 using namespace io::swagger::client::model;
 
+class  IPetApi
+{
+public:
+    virtual ~IPetApi() = default;
+    virtual pplx::task<void> addPet(
+        std::shared_ptr<Pet> body
+    ) = 0;
+    virtual pplx::task<void> deletePet(
+        int64_t petId,
+        boost::optional<utility::string_t> apiKey
+    ) = 0;
+    virtual pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByStatus(
+        std::vector<utility::string_t> status
+    ) = 0;
+    virtual pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByTags(
+        std::vector<utility::string_t> tags
+    ) = 0;
+    virtual pplx::task<std::shared_ptr<Pet>> getPetById(
+        int64_t petId
+    ) = 0;
+    virtual pplx::task<void> updatePet(
+        std::shared_ptr<Pet> body
+    ) = 0;
+    virtual pplx::task<void> updatePetWithForm(
+        int64_t petId,
+        boost::optional<utility::string_t> name,
+        boost::optional<utility::string_t> status
+    ) = 0;
+    virtual pplx::task<std::shared_ptr<ApiResponse>> uploadFile(
+        int64_t petId,
+        boost::optional<utility::string_t> additionalMetadata,
+        boost::optional<std::shared_ptr<HttpContent>> file
+    ) = 0;
+};
 
-class  PetApi 
+
+class  PetApi : public IPetApi
 {
 public:
     PetApi( std::shared_ptr<ApiClient> apiClient );
-    virtual ~PetApi();
+    ~PetApi() override;
     /// <summary>
     /// Add a new pet to the store
     /// </summary>
@@ -51,7 +86,7 @@ public:
     /// <param name="body">Pet object that needs to be added to the store</param>
     pplx::task<void> addPet(
         std::shared_ptr<Pet> body
-    );
+    ) override;
     /// <summary>
     /// Deletes a pet
     /// </summary>
@@ -63,7 +98,7 @@ public:
     pplx::task<void> deletePet(
         int64_t petId,
         boost::optional<utility::string_t> apiKey
-    );
+    ) override;
     /// <summary>
     /// Finds Pets by status
     /// </summary>
@@ -73,7 +108,7 @@ public:
     /// <param name="status">Status values that need to be considered for filter</param>
     pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByStatus(
         std::vector<utility::string_t> status
-    );
+    ) override;
     /// <summary>
     /// Finds Pets by tags
     /// </summary>
@@ -83,7 +118,7 @@ public:
     /// <param name="tags">Tags to filter by</param>
     pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByTags(
         std::vector<utility::string_t> tags
-    );
+    ) override;
     /// <summary>
     /// Find pet by ID
     /// </summary>
@@ -93,7 +128,7 @@ public:
     /// <param name="petId">ID of pet to return</param>
     pplx::task<std::shared_ptr<Pet>> getPetById(
         int64_t petId
-    );
+    ) override;
     /// <summary>
     /// Update an existing pet
     /// </summary>
@@ -103,7 +138,7 @@ public:
     /// <param name="body">Pet object that needs to be added to the store</param>
     pplx::task<void> updatePet(
         std::shared_ptr<Pet> body
-    );
+    ) override;
     /// <summary>
     /// Updates a pet in the store with form data
     /// </summary>
@@ -117,7 +152,7 @@ public:
         int64_t petId,
         boost::optional<utility::string_t> name,
         boost::optional<utility::string_t> status
-    );
+    ) override;
     /// <summary>
     /// uploads an image
     /// </summary>
@@ -131,7 +166,7 @@ public:
         int64_t petId,
         boost::optional<utility::string_t> additionalMetadata,
         boost::optional<std::shared_ptr<HttpContent>> file
-    );
+    ) override;
 
 protected:
     std::shared_ptr<ApiClient> m_ApiClient;

--- a/samples/client/petstore/cpprest/api/StoreApi.h
+++ b/samples/client/petstore/cpprest/api/StoreApi.h
@@ -35,7 +35,8 @@ namespace api {
 
 using namespace io::swagger::client::model;
 
-class  StoreApi
+
+class  StoreApi 
 {
 public:
     StoreApi( std::shared_ptr<ApiClient> apiClient );

--- a/samples/client/petstore/cpprest/api/StoreApi.h
+++ b/samples/client/petstore/cpprest/api/StoreApi.h
@@ -35,12 +35,29 @@ namespace api {
 
 using namespace io::swagger::client::model;
 
+class  IStoreApi
+{
+public:
+    virtual ~IStoreApi() = default;
+    virtual pplx::task<void> deleteOrder(
+        utility::string_t orderId
+    ) = 0;
+    virtual pplx::task<std::map<utility::string_t, int32_t>> getInventory(
+    ) = 0;
+    virtual pplx::task<std::shared_ptr<Order>> getOrderById(
+        int64_t orderId
+    ) = 0;
+    virtual pplx::task<std::shared_ptr<Order>> placeOrder(
+        std::shared_ptr<Order> body
+    ) = 0;
+};
 
-class  StoreApi 
+
+class  StoreApi : public IStoreApi
 {
 public:
     StoreApi( std::shared_ptr<ApiClient> apiClient );
-    virtual ~StoreApi();
+    ~StoreApi() override;
     /// <summary>
     /// Delete purchase order by ID
     /// </summary>
@@ -50,7 +67,7 @@ public:
     /// <param name="orderId">ID of the order that needs to be deleted</param>
     pplx::task<void> deleteOrder(
         utility::string_t orderId
-    );
+    ) override;
     /// <summary>
     /// Returns pet inventories by status
     /// </summary>
@@ -58,7 +75,7 @@ public:
     /// Returns a map of status codes to quantities
     /// </remarks>
     pplx::task<std::map<utility::string_t, int32_t>> getInventory(
-    );
+    ) override;
     /// <summary>
     /// Find purchase order by ID
     /// </summary>
@@ -68,7 +85,7 @@ public:
     /// <param name="orderId">ID of pet that needs to be fetched</param>
     pplx::task<std::shared_ptr<Order>> getOrderById(
         int64_t orderId
-    );
+    ) override;
     /// <summary>
     /// Place an order for a pet
     /// </summary>
@@ -78,7 +95,7 @@ public:
     /// <param name="body">order placed for purchasing the pet</param>
     pplx::task<std::shared_ptr<Order>> placeOrder(
         std::shared_ptr<Order> body
-    );
+    ) override;
 
 protected:
     std::shared_ptr<ApiClient> m_ApiClient;

--- a/samples/client/petstore/cpprest/api/UserApi.h
+++ b/samples/client/petstore/cpprest/api/UserApi.h
@@ -35,7 +35,8 @@ namespace api {
 
 using namespace io::swagger::client::model;
 
-class  UserApi
+
+class  UserApi 
 {
 public:
     UserApi( std::shared_ptr<ApiClient> apiClient );
@@ -86,7 +87,7 @@ public:
     /// <remarks>
     /// 
     /// </remarks>
-    /// <param name="username">The name that needs to be fetched. Use user1 for testing. </param>
+    /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
     pplx::task<std::shared_ptr<User>> getUserByName(
         utility::string_t username
     );

--- a/samples/client/petstore/cpprest/api/UserApi.h
+++ b/samples/client/petstore/cpprest/api/UserApi.h
@@ -35,12 +35,43 @@ namespace api {
 
 using namespace io::swagger::client::model;
 
+class  IUserApi
+{
+public:
+    virtual ~IUserApi() = default;
+    virtual pplx::task<void> createUser(
+        std::shared_ptr<User> body
+    ) = 0;
+    virtual pplx::task<void> createUsersWithArrayInput(
+        std::vector<std::shared_ptr<User>> body
+    ) = 0;
+    virtual pplx::task<void> createUsersWithListInput(
+        std::vector<std::shared_ptr<User>> body
+    ) = 0;
+    virtual pplx::task<void> deleteUser(
+        utility::string_t username
+    ) = 0;
+    virtual pplx::task<std::shared_ptr<User>> getUserByName(
+        utility::string_t username
+    ) = 0;
+    virtual pplx::task<utility::string_t> loginUser(
+        utility::string_t username,
+        utility::string_t password
+    ) = 0;
+    virtual pplx::task<void> logoutUser(
+    ) = 0;
+    virtual pplx::task<void> updateUser(
+        utility::string_t username,
+        std::shared_ptr<User> body
+    ) = 0;
+};
 
-class  UserApi 
+
+class  UserApi : public IUserApi
 {
 public:
     UserApi( std::shared_ptr<ApiClient> apiClient );
-    virtual ~UserApi();
+    ~UserApi() override;
     /// <summary>
     /// Create user
     /// </summary>
@@ -50,7 +81,7 @@ public:
     /// <param name="body">Created user object</param>
     pplx::task<void> createUser(
         std::shared_ptr<User> body
-    );
+    ) override;
     /// <summary>
     /// Creates list of users with given input array
     /// </summary>
@@ -60,7 +91,7 @@ public:
     /// <param name="body">List of user object</param>
     pplx::task<void> createUsersWithArrayInput(
         std::vector<std::shared_ptr<User>> body
-    );
+    ) override;
     /// <summary>
     /// Creates list of users with given input array
     /// </summary>
@@ -70,7 +101,7 @@ public:
     /// <param name="body">List of user object</param>
     pplx::task<void> createUsersWithListInput(
         std::vector<std::shared_ptr<User>> body
-    );
+    ) override;
     /// <summary>
     /// Delete user
     /// </summary>
@@ -80,7 +111,7 @@ public:
     /// <param name="username">The name that needs to be deleted</param>
     pplx::task<void> deleteUser(
         utility::string_t username
-    );
+    ) override;
     /// <summary>
     /// Get user by user name
     /// </summary>
@@ -90,7 +121,7 @@ public:
     /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
     pplx::task<std::shared_ptr<User>> getUserByName(
         utility::string_t username
-    );
+    ) override;
     /// <summary>
     /// Logs user into the system
     /// </summary>
@@ -102,7 +133,7 @@ public:
     pplx::task<utility::string_t> loginUser(
         utility::string_t username,
         utility::string_t password
-    );
+    ) override;
     /// <summary>
     /// Logs out current logged in user session
     /// </summary>
@@ -110,7 +141,7 @@ public:
     /// 
     /// </remarks>
     pplx::task<void> logoutUser(
-    );
+    ) override;
     /// <summary>
     /// Updated user
     /// </summary>
@@ -122,7 +153,7 @@ public:
     pplx::task<void> updateUser(
         utility::string_t username,
         std::shared_ptr<User> body
-    );
+    ) override;
 
 protected:
     std::shared_ptr<ApiClient> m_ApiClient;


### PR DESCRIPTION
We want to able to unit test our code that uses the generated API code.
In order to do that we need a virtual interface to mock away the
generated API code.

This PR introduces two new config options for the cpprest generator:
* "generateInterfacesForApis" will generate an abstract base class
  (interface) for all APIs.
* "generateGMocksForApis" will additionally generate Google Mock classes
  for the APIs. This config option of course implies the first one.

If the options are not set only minor white space changes will result
(see the changes in the petstore example).